### PR TITLE
Don't catch emails with dashes in bulleted lists as signatures

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -19,7 +19,7 @@ require 'strscan'
 #
 #     this is some text
 #
-#     -- 
+#     --
 #     Bob
 #     http://homepage.com/~bob
 #
@@ -85,7 +85,7 @@ class EmailReplyParser
       end
 
       # Finish up the final fragment.  Finishing a fragment will detect any
-      # attributes (hidden, signature, reply), and join each line into a 
+      # attributes (hidden, signature, reply), and join each line into a
       # string.
       finish_fragment
 
@@ -118,7 +118,7 @@ class EmailReplyParser
       # Mark the current Fragment as a signature if the current line is empty
       # and the Fragment starts with a common signature indicator.
       if @fragment && line == EMPTY
-        if @fragment.lines.last =~ /[\-\_]$/
+        if @fragment.lines.last =~ /(--|__|\w-)$/
           @fragment.signature = true
           finish_fragment
         end
@@ -165,10 +165,10 @@ class EmailReplyParser
     #
     #     Go fish! (visible)
     #
-    #     > -- 
+    #     > --
     #     > Player 1 (quoted, hidden)
     #
-    #     -- 
+    #     --
     #     Player 2 (signature, hidden)
     #
     def finish_fragment

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -71,6 +71,12 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_match /Loader/,   reply.fragments[1].to_s
   end
 
+  def test_a_complex_body_with_only_one_fragment
+    reply = email :email_1_5
+
+    assert_equal 1, reply.fragments.size
+  end
+
   def email(name)
     body = IO.read EMAIL_FIXTURE_PATH.join("#{name}.txt").to_s
     EmailReplyParser.read body

--- a/test/emails/email_1_5.txt
+++ b/test/emails/email_1_5.txt
@@ -1,0 +1,15 @@
+One: Here's what I've got.
+
+- This would be the first bullet point that wraps to the second line
+to the next
+- This is the second bullet point and it doesn't wrap
+- This is the third bullet point and I'm having trouble coming up with enough
+to say
+- This is the fourth bullet point
+
+Two:
+- Here is another bullet point
+- And another one
+
+This is a paragraph that talks about a bunch of stuff. It goes on and on
+for a while.


### PR DESCRIPTION
There were cases where bulleted lists that were prefixed by dashes were
considered signatures.
