### PR TITLE
Don't modify input string in place

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -62,7 +62,7 @@ class EmailReplyParser
     def read(text)
       # The text is reversed initially due to the way we check for hidden
       # fragments.
-      text.reverse!
+      text = text.reverse
 
       # This determines if any 'visible' Fragment has been found.  Once any
       # visible Fragment is found, stop looking for hidden ones.

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -71,6 +71,12 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_match /Loader/,   reply.fragments[1].to_s
   end
 
+  def test_does_not_modify_input_string
+    original = "The Quick Brown Fox Jumps Over The Lazy Dog"
+    EmailReplyParser.read original
+    assert_equal "The Quick Brown Fox Jumps Over The Lazy Dog", original
+  end
+
   def email(name)
     body = IO.read EMAIL_FIXTURE_PATH.join("#{name}.txt").to_s
     EmailReplyParser.read body


### PR DESCRIPTION
The current implementation reverses the input string in place.  This is a small fix to reverse a copy of the input string instead so that the input string is preserved for later use.
