### PR TITLE
Condense multiline reply headers to a single line.

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -60,6 +60,13 @@ class EmailReplyParser
     #
     # Returns this same Email instance.
     def read(text)
+      # Check for multi-line reply headers. Some clients break up
+      # the "On DATE, NAME <EMAIL> wrote:" line into multiple lines.
+      if text =~ /^(On(.+)wrote:)$/m
+        # Remove all new lines from the reply header.
+        text.gsub! $1, $1.gsub("\n", " ")
+      end
+
       # The text is reversed initially due to the way we check for hidden
       # fragments.
       text = text.reverse

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -71,6 +71,14 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_match /Loader/,   reply.fragments[1].to_s
   end
 
+  def test_deals_with_multiline_reply_headers
+    reply = email :email_1_5
+
+    assert_match /^I get/,   reply.fragments[0].to_s
+    assert_match /^On/,      reply.fragments[1].to_s
+    assert_match /Was this/, reply.fragments[1].to_s
+  end
+
   def test_does_not_modify_input_string
     original = "The Quick Brown Fox Jumps Over The Lazy Dog"
     EmailReplyParser.read original

--- a/test/emails/email_1_5.txt
+++ b/test/emails/email_1_5.txt
@@ -1,0 +1,15 @@
+I get proper rendering as well.
+
+Sent from a magnificent torch of pixels
+
+On Dec 16, 2011, at 12:47 PM, Corey Donohoe
+<reply@reply.github.com>
+wrote:
+
+> Was this caching related or fixed already?  I get proper rendering here.
+>
+> ![](https://img.skitch.com/20111216-m9munqjsy112yqap5cjee5wr6c.jpg)
+>
+> ---
+> Reply to this email directly or view it on GitHub:
+> https://github.com/github/github/issues/2278#issuecomment-3182418


### PR DESCRIPTION
Fixes stuff like @bleikamp's reply in github/github#2278
