### PR TITLE
Ensure that all lines of underscores have at least two preceding newlines

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -83,6 +83,12 @@ class EmailReplyParser
         text.gsub! $1, $1.gsub("\n", " ")
       end
 
+      # Some users may reply directly above a line of underscores.
+      # In order to ensure that these fragments are split correctly,
+      # make sure that all lines of underscores are preceded by
+      # at least two newline characters.
+      text.gsub!(/([^\n])(?=\n_{7}_+)$/m, "\\1\n")
+
       # The text is reversed initially due to the way we check for hidden
       # fragments.
       text = text.reverse

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -111,6 +111,11 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_equal "Outlook with a reply", EmailReplyParser.parse_reply(body)
   end
 
+  def test_parse_out_just_top_for_outlook_with_reply_directly_above_line
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_2_2.txt").to_s
+    assert_equal "Outlook with a reply directly above line", EmailReplyParser.parse_reply(body)
+  end
+
   def test_parse_out_sent_from_iPhone
     body = IO.read EMAIL_FIXTURE_PATH.join("email_iPhone.txt").to_s
     assert_equal "Here is another email", EmailReplyParser.parse_reply(body)

--- a/test/emails/email_2_2.txt
+++ b/test/emails/email_2_2.txt
@@ -1,0 +1,10 @@
+Outlook with a reply directly above line
+________________________________________
+From: CRM Comments [crm-comment@example.com]
+Sent: Friday, 23 March 2012 5:08 p.m.
+To: John S. Greene
+Subject: [contact:106] John Greene
+
+A new comment has been added to the Contact named 'John Greene':
+
+I am replying to a comment.


### PR DESCRIPTION
Some users may reply directly above a line of underscores, because the gap between lines can be a little misleading, e.g.

```
Outlook with a reply directly above line
________________________________________
From: CRM Comments [crm-comment@example.com]
Sent: Friday, 23 March 2012 5:08 p.m.
...
```

Unfortunately, the parser cannot split fragments without empty lines between them.

This pull request solves that problem by ensuring that all underscore lines are preceded by at least two newline characters. (I can't think of any situation where that would cause a problem.)

The previous example will be 'pre-processed' into:

```
Outlook with a reply directly above line

________________________________________
From: CRM Comments [crm-comment@example.com]
Sent: Friday, 23 March 2012 5:08 p.m.
...
```

But if _this_ ^ is run through the parser, it will not be affected.
