### PR TITLE
improved sig parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,15 @@ See more at the [Rocco docs][rocco].
 
 [rocco]: http://help.github.com/code/email_reply_parser/
 
-##Usage
+## Usage
 
 To parse reply body:
 
-`parsed_body = EmailReplyParser.parse_reply(email_body)`
+`parsed_body = EmailReplyParser.parse_reply(email_body, from_address)`
+
+The from_address is optional.  If included, it will attempt to parse out
+signatures based on the name in the from address (if signature doesn't have a
+standard delimiter.)
 
 ## Problem?
 
@@ -77,7 +81,7 @@ signatures:
 
     Hello
 
-    -- 
+    --
     Rick
 
 Not everyone follows this convention:
@@ -91,4 +95,3 @@ Not everyone follows this convention:
     **********************DISCLAIMER***********************************
     * Note: blah blah blah                                            *
     **********************DISCLAIMER***********************************
-

--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -34,20 +34,22 @@ class EmailReplyParser
 
   # Public: Splits an email body into a list of Fragments.
   #
-  # text - A String email body.
+  # text         - A String email body.
+  # from_address - A String From address of the email (optional)
   #
   # Returns an Email instance.
-  def self.read(text)
-    Email.new.read(text)
+  def self.read(text, from_address = nil)
+    Email.new.read(text, from_address)
   end
 
   # Public: Get the text of the visible portions of the given email body.
   #
-  # text - A String email body.
+  # text         - A String email body.
+  # from_address - A String From address of the email (optional)
   #
   # Returns a String.
-  def self.parse_reply(text)
-    self.read(text).visible_text
+  def self.parse_reply(text, from_address = nil)
+    self.read(text, from_address).visible_text
   end
 
   ### Emails
@@ -72,28 +74,19 @@ class EmailReplyParser
     # reversing the text and parsing from the bottom to the top.  This way we
     # can check for 'On <date>, <author> wrote:' lines above quoted blocks.
     #
-    # text - A String email body.
+    # text         - A String email body.
+    # from_address - A String From address of the email (optional)
     #
     # Returns this same Email instance.
-    def read(text)
-      # in 1.9 we want to operate on the raw bytes
-      text = text.dup.force_encoding('binary') if text.respond_to?(:force_encoding)
+    def read(text, from_address = nil)
+      from_address ||= ""
 
-      # Normalize line endings.
-      text.gsub!("\r\n", "\n")
+      # parse out the from name if one exists and save for use later
+      @from_name_raw = parse_raw_name_from_address(from_address)
+      @from_name_normalized = normalize_name(@from_name_raw)
+      @from_email = parse_email_from_address(from_address)
 
-      # Check for multi-line reply headers. Some clients break up
-      # the "On DATE, NAME <EMAIL> wrote:" line into multiple lines.
-      if text =~ /^(On\s(.+)wrote:)$/nm
-        # Remove all new lines from the reply header.
-        text.gsub! $1, $1.gsub("\n", " ")
-      end
-
-      # Some users may reply directly above a line of underscores.
-      # In order to ensure that these fragments are split correctly,
-      # make sure that all lines of underscores are preceded by
-      # at least two newline characters.
-      text.gsub!(/([^\n])(?=\n_{7}_+)$/m, "\\1\n")
+      text = normalize_text(text)
 
       # The text is reversed initially due to the way we check for hidden
       # fragments.
@@ -142,6 +135,86 @@ class EmailReplyParser
       SIG_REGEX = Regexp.new(SIGNATURE)
     end
 
+    # normalize text so it is easier to parse
+    #
+    # text - String text to normalize
+    #
+    # Returns a String
+    #
+    def normalize_text(text)
+      # in 1.9 we want to operate on the raw bytes
+      text = text.dup.force_encoding("binary") if text.respond_to?(:force_encoding)
+
+      # Normalize line endings.
+      text.gsub!("\r\n", "\n")
+
+      # Check for multi-line reply headers. Some clients break up
+      # the "On DATE, NAME <EMAIL> wrote:" line into multiple lines.
+      if match = text.match(/^(On\s(.+)wrote:)$/m)
+        # Remove all new lines from the reply header. as long as we don't have any double newline
+        # if we do they we have grabbed something that is not actually a reply header
+        text.gsub! match[1], match[1].gsub("\n", " ") unless match[1] =~ /\n\n/
+      end
+
+      # Some users may reply directly above a line of underscores.
+      # In order to ensure that these fragments are split correctly,
+      # make sure that all lines of underscores are preceded by
+      # at least two newline characters.
+      text.gsub!(/([^\n])(?=\n_{7}_+)$/m, "\\1\n")
+      text
+    end
+
+    # Parse a person's name from an e-mail address
+    #
+    # email - String email address.
+    #
+    # Returns a String.
+    def parse_name_from_address(address)
+      raw_name = parse_raw_name_from_address(address)
+      normalize_name(raw_name)
+    end
+
+    def parse_raw_name_from_address(address)
+      match = address.match(/^["']*([\w\s,]+)["']*\s*</)
+      unless match.nil?
+        match[1].strip.to_s
+      else
+        ""
+      end
+    end
+
+    def parse_email_from_address(address)
+      match = address.match /<(.*)>/
+      if match.nil?
+        address
+      else
+        match[1]
+      end
+    end
+
+    # Normalize a name to First Last
+    #
+    # name - name to normailze.
+    #
+    # Returns a String.
+
+    def normalize_name(name)
+      if name.include?(',')
+        make_name_first_then_last(name)
+       else
+        name
+      end
+    end
+
+    def make_name_first_then_last(name)
+      split_name = name.split(',')
+      if split_name[0].include?(" ")
+        split_name[0].to_s
+      else
+        split_name[1].strip + " " + split_name[0].strip
+      end
+    end
+
     ### Line-by-Line Parsing
 
     # Scans the given line of text and figures out which fragment it belongs
@@ -152,7 +225,7 @@ class EmailReplyParser
     # Returns nothing.
     def scan_line(line)
       line.chomp!("\n")
-      line.lstrip! unless SIG_REGEX.match(line) 
+      line.lstrip! unless signature_line?(line)
 
       # We're looking for leading `>`'s to see if this line is part of a
       # quoted Fragment.
@@ -161,8 +234,15 @@ class EmailReplyParser
       # Mark the current Fragment as a signature if the current line is empty
       # and the Fragment starts with a common signature indicator.
       if @fragment && line == EMPTY
-        if SIG_REGEX.match @fragment.lines.last
-          @fragment.signature = true
+        last_line = @fragment.lines.last
+        is_signature = signature_line?(last_line)
+        is_multiline_quote_header = multiline_quote_header_in_fragment?(@fragment)
+        if is_signature || is_multiline_quote_header
+          if is_signature
+            @fragment.signature = true
+          else
+            @fragment.quoted = true
+          end
           finish_fragment
         end
       end
@@ -182,14 +262,123 @@ class EmailReplyParser
       end
     end
 
-    # Detects if a given line is a header above a quoted area.  It is only
-    # checked for lines preceding quoted regions.
+    # Detects if a given line is a header above a quoted area.
     #
     # line - A String line of text from the email.
     #
     # Returns true if the line is a valid header, or false.
     def quote_header?(line)
-      line =~ /^:etorw.*nO$/n
+      standard_header_regexp = reverse_regexp("On\s.+wrote:$")
+      line =~ standard_header_regexp
+    end
+
+    # Detects if a fragment has a multiline quote header
+    #
+    # fragment - fragment to look in
+    #
+    # Returns true if the fragment has header, or false.
+
+    def multiline_quote_header_in_fragment?(fragment)
+      fragment_text = @fragment.lines.join("\n")
+
+      from_labels = ["From", "De"]
+      to_labels = ["To", "Para"]
+      date_labels = ["Date", "Sent", "Enviada em"]
+      subject_labels = ["Subject", "Assunto"]
+      reply_to_labels = ["Reply-To"]
+
+      quoted_header_regexp =
+        multiline_quoted_header_regexps(
+          :from => create_regexp_for_labels(from_labels),
+          :to => create_regexp_for_labels(to_labels),
+          :date => create_regexp_for_labels(date_labels),
+          :subject => create_regexp_for_labels(subject_labels),
+          :reply_to => create_regexp_for_labels(reply_to_labels)
+        )
+
+      fragment_text =~ quoted_header_regexp
+    end
+
+    # create regexp for multiline quote headers
+    #
+    # labels - hash of labels
+    #
+    # Returns Regexp
+    def multiline_quoted_header_regexps(labels)
+      quoted_header_regexps = []
+
+      quoted_header_regexps <<  "#{labels[:date]}:.*\n#{labels[:from]}:.*\n#{labels[:to]}:.*\n#{labels[:subject]}:.*"
+      quoted_header_regexps << "#{labels[:from]}:.*\n#{labels[:date]}:.*\n#{labels[:to]}:.*\n#{labels[:subject]}:.*"
+      quoted_header_regexps << "#{labels[:from]}:.*\n#{labels[:to]}:.*\n#{labels[:date]}:.*\n#{labels[:subject]}:.*"
+      quoted_header_regexps << "#{labels[:from]}:.*\n#{labels[:reply_to]}:.*\n#{labels[:date]}:.*\n#{labels[:to]}:.*\n#{labels[:subject]}:.*"
+
+      reverse_regexp("(#{quoted_header_regexps.join("|")})")
+    end
+
+    # create regexp that will search for any from a list of labels
+    #
+    # labels - Array of text strings
+    #
+    # Returns regexp string
+    def create_regexp_for_labels(labels)
+      "(#{labels.join("|")})"
+    end
+
+    # reverses a regular expression
+    #
+    # regexp      - String or Regexp that you want to reverse
+    # ignore_case - where to the returned Regexp should be case insensitive
+    #
+    # Returns Regexp
+    def reverse_regexp(regexp, ignore_case = true)
+      regexp_text = regexp.to_s.reverse
+      regexp_text.gsub!("*.", ".*")
+      regexp_text.gsub!("+.", ".+")
+      regexp_text.gsub!("$", "^")
+      regexp_text = reverse_parentheses(regexp_text)
+
+      regexp_options = []
+      regexp_options << Regexp::IGNORECASE if ignore_case
+      Regexp.new(regexp_text, *regexp_options)
+    end
+
+    # reverses parentheses in a string
+    #
+    # text - String or Regexp that you want to reverse
+    #
+    # Returns String
+    def reverse_parentheses(text)
+      text.gsub!(/\)(.*)\(/m, '(\1)')  # reverses outter parentheses
+      text.gsub!(/\)(.*?)\(/m, '(\1)') # reverses nested parentheses
+      text
+    end
+
+    # Detects if a given line is the beginning of a signature
+    #
+    # line - A String line of text from the email.
+    #
+    # Returns true if the line is the beginning of a signature, or false.
+    def signature_line?(line)
+      return true if SIG_REGEX.match(line)
+      line_is_signature_name?(line)
+    end
+
+    # Detects if the @from name is a big part of a given line and therefore the beginning of a signature
+    #
+    # line - A String line of text from the email.
+    #
+    # Returns true if @from_name is a big part of the line, or false.
+    def line_is_signature_name?(line)
+      regexp = generate_regexp_for_name
+      @from_name_normalized != "" && (line =~ regexp) && ((@from_name_normalized.size.to_f / line.size) > 0.25)
+    end
+
+    # generates regexp which always for additional words or initials between
+    # first and last names
+    def generate_regexp_for_name
+      name_parts = @from_name_normalized.reverse.split(" ")
+      seperator = '[\w.\s]*'
+      regexp = Regexp.new(name_parts.join(seperator), Regexp::IGNORECASE)
     end
 
     # Builds the fragment string and reverses it, after all lines have been

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -155,17 +155,174 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_equal EmailReplyParser.read(body).visible_text, EmailReplyParser.parse_reply(body)
   end
 
+  def test_parse_out_signature_using_from_name
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_no_signature_deliminator.txt").to_s
+    expected_body = "I don't like putting any delimiator in my signature because I think that is cool.\n\nReally it is."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "Jim Smith <john.smith@gmail.com>")
+  end
+
+ def test_parse_out_signature_using_from_name_different_case
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_no_signature_deliminator.txt").to_s
+    expected_body = "I don't like putting any delimiator in my signature because I think that is cool.\n\nReally it is."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "jim smith <john.smith@gmail.com>")
+  end
+
+
+  def test_parse_out_signature_using_from_name_last_then_first
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_no_signature_deliminator.txt").to_s
+    expected_body = "I don't like putting any delimiator in my signature because I think that is cool.\n\nReally it is."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, '"Smith, Jim" <john.smith@gmail.com>')
+  end
+
+  def test_parse_out_signature_using_from_name_when_middle_initial_is_in_signature
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_no_signature_deliminator_adds_a_middle_initial.txt").to_s
+    expected_body = "I don't like putting any delimiator in my signature because I think that is cool.\n\nReally it is."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "Jim Smith <john.smith@gmail.com>")
+  end
+
+  def test_that_a_sentence_with_my_name_in_it_does_not_become_a_signature
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_mentions_own_name.txt").to_s
+    expected_body = "Hi,\n\nMy name is Jim Smith and I had a question.\n\nWhat do you do?"
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "Jim Smith <john.smith@gmail.com>")
+  end
+
+  def test_simple_email_with_reply
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_was_showing_as_nothing_visible.txt").to_s
+    expected_body = "On Friday, one achievement I had was learning a new technology that allows us
+to keep UI elements and events separated from the software on the
+server side, which should allow for more flexible UI code and
+decreased chances of code becoming a swarm of angry hornets.  I've
+been transparent about the initial increased development time while
+learning the technology."
+
+    assert_equal expected_body, EmailReplyParser.parse_reply(body)
+  end
+
+  def test_2nd_paragraph_starts_with_on
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_2nd_paragraph_starting_with_on.txt").to_s
+    expected_body = "This emails tests that multiline header fix isn't catching things it shouldn't.
+
+On friday when I tried it didn't work as expect.
+
+This line would have been considered part of the header line."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body)
+  end
+
+  def test_from_email_in_quote_header
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_from_address_in_quote_header.txt").to_s
+    expected_body = "I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "shelly@example.com")
+  end
+
+  def test_do_not_make_any_line_with_from_address_quote_heading
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_mentions_own_email_address.txt").to_s
+    expected_body = "Hi,\n\nMy email is john.smith@gmail.com and I had a question.\n\nWhat do you do?"
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "Jim Smith <john.smith@gmail.com>")
+  end
+
+  def test_from_name_in_quote_header
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_from_name_in_quote_header.txt").to_s
+    expected_body = "I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "Smith, Shelly <shelly@example.com>")
+  end
+
+  def test_multiline_quote_header_from_first
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_multiline_quote_header_from_first.txt").to_s
+    expected_body = "I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "Smith, Shelly <shelly@example.com>")
+  end
+
+  def test_multiline_quote_header_from_to_date_subject
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_multiline_quote_header_from_to_date_subject.txt").to_s
+    expected_body = "I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "Smith, Shelly <shelly@example.com>")
+  end
+
+  def test_multiline_quote_header_from_to_date_subject
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_multiline_quote_header_from_replyto_date_to_subject.txt").to_s
+    expected_body = "I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "Smith, Shelly <shelly@example.com>")
+  end
+
+  def test_multiline_quote_header_pt_br
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_multiline_quote_header_pt_br.txt").to_s
+    expected_body = "I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general."
+    assert_equal expected_body, EmailReplyParser.parse_reply(body, "Smith, Shelly <shelly@example.com>")
+  end
+
+  def test_parsing_name_from_address
+    address = "Bob Jones <bob@gmail.com>"
+    email = EmailReplyParser::Email.new
+    assert_equal "Bob Jones", email.send(:parse_name_from_address, address)
+  end
+
+  def test_parsing_name_from_address_with_double_quotes
+    address = "\"Bob Jones\" <bob@gmail.com>"
+    email = EmailReplyParser::Email.new
+    assert_equal "Bob Jones", email.send(:parse_name_from_address, address)
+  end
+
+  def test_parsing_name_from_address_with_single_quotes
+    address = "'Bob Jones' <bob@gmail.com>"
+    email = EmailReplyParser::Email.new
+    assert_equal "Bob Jones", email.send(:parse_name_from_address, address)
+  end
+
+  def test_parsing_name_from_address_with_no_name
+    address = "bob@gmail.com"
+    email = EmailReplyParser::Email.new
+    assert_equal "", email.send(:parse_name_from_address, address)
+  end
+
+  def test_parsing_email_from_address_with_name
+    address = "\"Bob Jones\" <bob@gmail.com>"
+    email = EmailReplyParser::Email.new
+    assert_equal "bob@gmail.com", email.send(:parse_email_from_address, address)
+  end
+
+  def test_parsing_email_from_address_without_name
+    address = "bob@gmail.com"
+    email = EmailReplyParser::Email.new
+    assert_equal "bob@gmail.com", email.send(:parse_email_from_address, address)
+  end
+
+  def test_reverse_regexp_string
+    email = EmailReplyParser::Email.new
+    regexp = "(a(b|c).*\ndef)$"
+    assert_equal Regexp.new("^(fed\n.*(c|b)a)", Regexp::IGNORECASE), email.send(:reverse_regexp, regexp)
+  end
+
   def test_one_is_not_on
     reply = email("email_one_is_not_on")
     assert_match /One outstanding question/, reply.fragments[0].to_s
     assert_match /^On Oct 1, 2012/, reply.fragments[1].to_s
   end
 
+  def test_normalize_name_first_last
+    email = EmailReplyParser::Email.new
+    name = "John Smith"
+    assert_equal name, email.send(:normalize_name, name)
+  end
+
+  def test_normalize_name_last_first
+    email = EmailReplyParser::Email.new
+    name = "Smith, John"
+    assert_equal "John Smith", email.send(:normalize_name, name)
+  end
+
+  def test_normalize_name_first_last_and_qualification
+    email = EmailReplyParser::Email.new
+    name = "John Smith, MD"
+    assert_equal "John Smith", email.send(:normalize_name, name)
+  end
+
+if !ENV["SKIP_RE2_TEST"]
   def test_pathological_emails
     t0 = Time.now
     reply = email("pathological")
     assert (Time.now - t0) < 1, "Took too long, upgrade to re2 gem."
   end
+end
 
   def email(name)
     body = IO.read EMAIL_FIXTURE_PATH.join("#{name}.txt").to_s

--- a/test/emails/email_2nd_paragraph_starting_with_on.txt
+++ b/test/emails/email_2nd_paragraph_starting_with_on.txt
@@ -1,0 +1,12 @@
+This emails tests that multiline header fix isn't catching things it shouldn't.
+
+On friday when I tried it didn't work as expect.
+
+This line would have been considered part of the header line.
+
+On Wed, Apr 4, 2012 at 9:32 AM, Bob Jones <bjones@gmail.com> wrote:
+> We are still very interested in achievements you’ve had from participating
+> in our initiative.  When you have a chance, please reply to this
+> email and describe what you have done.
+>
+

--- a/test/emails/email_from_address_in_quote_header.txt
+++ b/test/emails/email_from_address_in_quote_header.txt
@@ -1,0 +1,12 @@
+I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general.
+
+
+Date: Tue, 2 Oct 2012 02:35:10 +0000 
+From: john@example.com 
+To: shelly@example.com 
+Subject: Tell us what you learned.
+
+
+
+
+Thank you for recently participating in our class. We're interested in feedback. Please reply to this email. 

--- a/test/emails/email_from_name_in_quote_header.txt
+++ b/test/emails/email_from_name_in_quote_header.txt
@@ -1,0 +1,12 @@
+I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general.
+
+
+Date: Tue, 2 Oct 2012 02:35:10 +0000 
+From: john@example.com 
+To: Smith, Shelly 
+Subject: Tell us what you learned.
+
+
+
+
+Thank you for recently participating in our class. We're interested in feedback. Please reply to this email. 

--- a/test/emails/email_mentions_own_email_address.txt
+++ b/test/emails/email_mentions_own_email_address.txt
@@ -1,0 +1,6 @@
+Hi, 
+
+My email is john.smith@gmail.com and I had a question.  
+
+What do you do?
+

--- a/test/emails/email_mentions_own_name.txt
+++ b/test/emails/email_mentions_own_name.txt
@@ -1,0 +1,6 @@
+Hi, 
+
+My name is Jim Smith and I had a question.  
+
+What do you do?
+

--- a/test/emails/email_multiline_quote_header_from_first.txt
+++ b/test/emails/email_multiline_quote_header_from_first.txt
@@ -1,0 +1,11 @@
+I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general.
+
+From: john@example.com 
+Sent: Tue, 2 Oct 2012 02:35:10 +0000 
+To: shelly@example.com 
+Subject: Tell us what you learned.
+
+
+
+
+Thank you for recently participating in our class. We're interested in feedback. Please reply to this email. 

--- a/test/emails/email_multiline_quote_header_from_replyto_date_to_subject.txt
+++ b/test/emails/email_multiline_quote_header_from_replyto_date_to_subject.txt
@@ -1,0 +1,12 @@
+I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general.
+
+From: john@example.com 
+Reply-To: john@example.com
+Sent: Tue, 2 Oct 2012 02:35:10 +0000 
+To: shelly@example.com 
+Subject: Tell us what you learned.
+
+
+
+
+Thank you for recently participating in our class. We're interested in feedback. Please reply to this email. 

--- a/test/emails/email_multiline_quote_header_from_to_date_subject.txt
+++ b/test/emails/email_multiline_quote_header_from_to_date_subject.txt
@@ -1,0 +1,11 @@
+I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general.
+
+From: john@example.com 
+To: shelly@example.com 
+Date: Tue, 2 Oct 2012 02:35:10 +0000 
+Subject: Tell us what you learned.
+
+
+
+
+Thank you for recently participating in our class. We're interested in feedback. Please reply to this email. 

--- a/test/emails/email_multiline_quote_header_pt_br.txt
+++ b/test/emails/email_multiline_quote_header_pt_br.txt
@@ -1,0 +1,8 @@
+I have gained valuable experience from working with students from other cultures. They bring a significantly different perspective to the work we do. I have also had the opportunity to practice making myself very clear in discussion, so that everyone understands. I've also seen how different our culture is to them, in their reactions to what I think is a normal approach to assignments, and to life in general.
+
+De: john@example.com
+Enviada em: sexta-feira, 27 de julho de 2012 15:09
+Para: shelly@example.com 
+Assunto: Tell us what you learned.
+
+Thank you for recently participating in our class. We're interested in feedback. Please reply to this email. 

--- a/test/emails/email_no_signature_deliminator.txt
+++ b/test/emails/email_no_signature_deliminator.txt
@@ -1,0 +1,7 @@
+I don't like putting any delimiator in my signature because I think that is cool.  
+
+Really it is.
+
+Jim Smith | Enrollment Manager
+XYZ Corp
+

--- a/test/emails/email_no_signature_deliminator_adds_a_middle_initial.txt
+++ b/test/emails/email_no_signature_deliminator_adds_a_middle_initial.txt
@@ -1,0 +1,7 @@
+I don't like putting any delimiator in my signature because I think that is cool.  
+
+Really it is.
+
+Jim P. Smith | Enrollment Manager
+XYZ Corp
+

--- a/test/emails/email_was_showing_as_nothing_visible.txt
+++ b/test/emails/email_was_showing_as_nothing_visible.txt
@@ -1,0 +1,13 @@
+On Friday, one achievement I had was learning a new technology that allows us
+to keep UI elements and events separated from the software on the
+server side, which should allow for more flexible UI code and
+decreased chances of code becoming a swarm of angry hornets.  I've
+been transparent about the initial increased development time while
+learning the technology.
+
+On Wed, Apr 4, 2012 at 9:32 AM, Bob Jones <bjones@gmail.com> wrote:
+> We are still very interested in achievements you’ve had from participating
+> in our initiative.  When you have a chance, please reply to this
+> email and describe what you have done.
+>
+


### PR DESCRIPTION
Attempts to identify the beginning of a signature by matching the from address.  Useful if no signature delimiter is available.

Based on work from #9.