### PR TITLE
Don't interpret signature delimiter in the middle of line as signature

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -133,7 +133,7 @@ class EmailReplyParser
 
   private
     EMPTY = "".freeze
-    SIGNATURE = '(?m)(--|__|\w-$)|(^(\w+\s*){1,3} ym morf tneS$)'
+    SIGNATURE = '(?m)^(--|__|\w-$)|(^(\w+\s*){1,3} ym morf tneS$)'
 
     begin
       require 're2'

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -167,6 +167,11 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert (Time.now - t0) < 1, "Took too long, upgrade to re2 gem."
   end
 
+  def test_doesnt_remove_signature_delimiter_in_mid_line
+    reply = email(:email_sig_delimiter_in_middle_of_line)
+    assert_equal 1, reply.fragments.size
+  end
+
   def email(name)
     body = IO.read EMAIL_FIXTURE_PATH.join("#{name}.txt").to_s
     EmailReplyParser.read body

--- a/test/emails/email_sig_delimiter_in_middle_of_line.txt
+++ b/test/emails/email_sig_delimiter_in_middle_of_line.txt
@@ -1,0 +1,7 @@
+Hi there!
+
+Stuff happened.
+
+And here is a fix -- this is not a signature.
+
+kthxbai


### PR DESCRIPTION
This fixes the problem described in issue https://github.com/github/email_reply_parser/issues/17
