### PR TITLE
Add failing test for parsing inline replies

### DIFF
--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -63,6 +63,25 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_match /^_/, reply.fragments[5].to_s
   end
 
+  def test_reads_inline_replies
+    reply = email(:email_1_8)
+    assert_equal 6, reply.fragments.size
+
+    assert_equal [true, false, true, false, false, false],
+      reply.fragments.map { |f| f.quoted? }
+    assert_equal [false, false, false, false, false, true],
+      reply.fragments.map { |f| f.signature? }
+    assert_equal [false, false, false, false, true, true],
+      reply.fragments.map { |f| f.hidden? }
+
+    assert_match /^On [^\:]+\:/, reply.fragments[0].to_s
+    assert_match /^I will reply/, reply.fragments[1].to_s
+    assert_match /^> /, reply.fragments[2].to_s
+    assert_match /^and under this./, reply.fragments[3].to_s
+    assert_match /^> /, reply.fragments[4].to_s
+    assert_match /^-/, reply.fragments[5].to_s
+  end
+
   def test_recognizes_date_string_above_quote
     reply = email :email_1_4
 

--- a/test/emails/email_1_8.txt
+++ b/test/emails/email_1_8.txt
@@ -1,0 +1,37 @@
+On Tue, Apr 29, 2014 at 4:22 PM, Example Dev <sugar@example.com>wrote:
+
+> okay.  Well, here's some stuff I can write.
+>
+> And if I write a 2 second line you and maybe reply under this?
+>
+> Or if you didn't really feel like it, you could reply under this line.Or
+> if you didn't really feel like it, you could reply under this line. Or if
+> you didn't really feel like it, you could reply under this line. Or if you
+> didn't really feel like it, you could reply under this line.
+>
+
+I will reply under this one
+
+>
+> okay?
+>
+
+and under this.
+
+>
+> -- Tim
+>
+> On Tue, April 29, 2014 at 4:21 PM, Tim Haines <tmhaines@example.com> wrote:
+> > hi there
+> >
+> > After you reply to this I'm going to send you some inline responses.
+> >
+> > --
+> > Hey there, this is my signature
+>
+>
+>
+
+
+--
+Hey there, this is my signature


### PR DESCRIPTION
Hey there.  I noticed that this was working different to how I expected for inline replies.  This test fails, but perhaps my expectations about how this email should be parsed are incorrect?
