### PR TITLE
Change support URL to github.com/support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To parse reply body:
 
 If you have a question about the behavior and formatting of email replies on GitHub, check out [support][support].  If you have a specific issue regarding this library, then hit up the [Issues][issues].
 
-[support]: http://support.github.com/
+[support]: http://github.com/support
 [issues]: https://github.com/github/email_reply_parser/issues
 
 ## Installation


### PR DESCRIPTION
FQDN for support.github.com redirects to github.com
