### PR TITLE
Make reply header regexp even less greedy

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -84,7 +84,7 @@ class EmailReplyParser
 
       # Check for multi-line reply headers. Some clients break up
       # the "On DATE, NAME <EMAIL> wrote:" line into multiple lines.
-      if text =~ /^(On\s(.+?)wrote:)$/nm
+      if text =~ /^(?!On.*On\s.+?wrote:)(On\s(.+?)wrote:)$/nm
         # Remove all new lines from the reply header.
         text.gsub! $1, $1.gsub("\n", " ")
       end


### PR DESCRIPTION
This is the fix to #23. It uses the negative lookahead assertion to prevent matches where On appears twice.

The whitespace matcher after the second on is required to make sure that people with names beginning with 'On' don't trigger it.
