### PR TITLE
Remove binary encoding

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -76,15 +76,12 @@ class EmailReplyParser
     #
     # Returns this same Email instance.
     def read(text)
-      # in 1.9 we want to operate on the raw bytes
-      text = text.dup.force_encoding('binary') if text.respond_to?(:force_encoding)
-
       # Normalize line endings.
       text.gsub!("\r\n", "\n")
 
       # Check for multi-line reply headers. Some clients break up
       # the "On DATE, NAME <EMAIL> wrote:" line into multiple lines.
-      if text =~ /^(?!On.*On\s.+?wrote:)(On\s(.+?)wrote:)$/nm
+      if text =~ /^(?!On.*On\s.+?wrote:)(On\s(.+?)wrote:)$/m
         # Remove all new lines from the reply header.
         text.gsub! $1, $1.gsub("\n", " ")
       end
@@ -110,7 +107,7 @@ class EmailReplyParser
 
       # Use the StringScanner to pull out each line of the email content.
       @scanner = StringScanner.new(text)
-      while line = @scanner.scan_until(/\n/n)
+      while line = @scanner.scan_until(/\n/)
         scan_line(line)
       end
 
@@ -156,7 +153,7 @@ class EmailReplyParser
 
       # We're looking for leading `>`'s to see if this line is part of a
       # quoted Fragment.
-      is_quoted = !!(line =~ /(>+)$/n)
+      is_quoted = !!(line =~ /(>+)$/)
 
       # Mark the current Fragment as a signature if the current line is empty
       # and the Fragment starts with a common signature indicator.
@@ -189,7 +186,7 @@ class EmailReplyParser
     #
     # Returns true if the line is a valid header, or false.
     def quote_header?(line)
-      line =~ /^:etorw.*nO$/n
+      line =~ /^:etorw.*nO$/
     end
 
     # Builds the fragment string and reverses it, after all lines have been

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -123,6 +123,11 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_match /Steps 0-2/, reply.fragments[1].to_s
   end
 
+  def test_handles_non_ascii_characters
+    non_ascii_body = "Here’s a test."
+    assert_equal non_ascii_body, EmailReplyParser.parse_reply(non_ascii_body)
+  end
+
   def test_does_not_modify_input_string
     original = "The Quick Brown Fox Jumps Over The Lazy Dog"
     EmailReplyParser.read original


### PR DESCRIPTION
Fixes https://github.com/github/email_reply_parser/issues/10

In certain situations, force encoding to binary gives some unwanted results. For example, when parsing `Here’s a test.`, you would get `Here\xE2\x80\x99s a test.` as the first and only fragment. 

With the following change, you get `Here’s a test.`

Maybe we should specify a minimum ruby version (>= 2.0) if there is an issue that requires to force encode with ruby 1.9??
