### PR TITLE
Fix multi-line reply headers when there are quoted ones below

### DIFF
--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -115,6 +115,13 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_match /Was this/, reply.fragments[1].to_s
   end
 
+  def test_multiline_and_quoted_reply_headers
+    reply = email :broken_reply_header
+
+    assert_match /^On the other hand/,   reply.fragments[0].to_s
+    assert_match /^On Wed, Dec 9/,   reply.fragments[1].to_s
+  end
+
   def test_deals_with_windows_line_endings
     reply = email :email_1_7
 

--- a/test/emails/broken_reply_header.txt
+++ b/test/emails/broken_reply_header.txt
@@ -1,0 +1,29 @@
+This is the latest reply.
+
+The thread contains two previous replies, and the most recent reply header has a line break in it.
+
+If we don't patch the line break, the reply header ends up in THIS fragment, instead of in the quoted fragment.
+
+On the one hand, there could be a line in the reply starting with the word 'On.'
+
+On the other hand, it could happen TWICE!
+
+Stranger
+
+On Wed, Dec 9, Mister Example
+<mrmister@example.com>
+wrote:
+> Hey, Stranger,
+> It's mrmister again, and I hope you reply to me. I also hope this fragment has my reply header in it!
+>
+> -mrmister
+>
+> On Tue, 2011-03-01 at 18:02 +0530, Stranger Jones wrote:
+>> Hey, mrmister,
+>>
+>> I'm getting tired of writing fake email text.
+>>
+>> Stranger
+
+--
+My name is Stranger


### PR DESCRIPTION
This is to address #47. I wasn't able to solve this issue by tweaking the negative lookahead in the RegEx, but perhaps somebody else can. I'm definitely open to a better solution that addresses the test case.
