### PR TITLE
don't force encode emails to binary

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -76,15 +76,14 @@ class EmailReplyParser
     #
     # Returns this same Email instance.
     def read(text)
-      # in 1.9 we want to operate on the raw bytes
-      text = text.dup.force_encoding('binary') if text.respond_to?(:force_encoding)
+      text = text.dup
 
       # Normalize line endings.
       text.gsub!("\r\n", "\n")
 
       # Check for multi-line reply headers. Some clients break up
       # the "On DATE, NAME <EMAIL> wrote:" line into multiple lines.
-      if text =~ /^(?!On.*On\s.+?wrote:)(On\s(.+?)wrote:)$/nm
+      if text =~ /^(?!On.*On\s.+?wrote:)(On\s(.+?)wrote:)$/m
         # Remove all new lines from the reply header.
         text.gsub! $1, $1.gsub("\n", " ")
       end
@@ -110,7 +109,7 @@ class EmailReplyParser
 
       # Use the StringScanner to pull out each line of the email content.
       @scanner = StringScanner.new(text)
-      while line = @scanner.scan_until(/\n/n)
+      while line = @scanner.scan_until(/\n/)
         scan_line(line)
       end
 
@@ -156,7 +155,7 @@ class EmailReplyParser
 
       # We're looking for leading `>`'s to see if this line is part of a
       # quoted Fragment.
-      is_quoted = !!(line =~ /(>+)$/n)
+      is_quoted = !!(line =~ /(>+)$/)
 
       # Mark the current Fragment as a signature if the current line is empty
       # and the Fragment starts with a common signature indicator.
@@ -189,7 +188,7 @@ class EmailReplyParser
     #
     # Returns true if the line is a valid header, or false.
     def quote_header?(line)
-      line =~ /^:etorw.*nO$/n
+      line =~ /^:etorw.*nO$/
     end
 
     # Builds the fragment string and reverses it, after all lines have been

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -9,6 +9,17 @@ require dir + '..' + 'lib' + 'email_reply_parser'
 EMAIL_FIXTURE_PATH = dir + 'emails'
 
 class EmailReplyParserTest < Test::Unit::TestCase
+  def test_encoding_should_be_maintained
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_1_1.txt").to_s
+    EmailReplyParser.read body
+    reply = email(:email_1_1)
+    fragments = reply.fragments
+    refute_predicate fragments, :empty?
+    fragments.each do |fragment|
+      assert_equal body.encoding, fragment.to_s.encoding
+    end
+  end
+
   def test_reads_simple_body
     reply = email(:email_1_1)
     assert_equal 3, reply.fragments.size


### PR DESCRIPTION
We should assume that incoming data is tagged and scrubbed correctly.
We are not working with binary data.