### PR TITLE
Check for Outlook headers without a seperator

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -88,6 +88,12 @@ class EmailReplyParser
         text.gsub! $1, $1.gsub("\n", " ")
       end
 
+      # Check for Windows Live multi-line reply headers.
+      if text =~ /^(From:\s.+?Subject:.+?)$/m
+        text.gsub! $1, $1.gsub("\n", " ")
+      end
+
+
       # Some users may reply directly above a line of underscores.
       # In order to ensure that these fragments are split correctly,
       # make sure that all lines of underscores are preceded by
@@ -188,7 +194,7 @@ class EmailReplyParser
     #
     # Returns true if the line is a valid header, or false.
     def quote_header?(line)
-      line =~ /^:etorw.*nO$/
+      line =~ /^:etorw.*nO$/ || line =~ /^.*:(morF|tneS|oT|tcejbuS)$/
     end
 
     # Builds the fragment string and reverses it, after all lines have been

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -160,6 +160,11 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_equal "Outlook with a reply directly above line", EmailReplyParser.parse_reply(body)
   end
 
+  def test_parse_out_just_top_for_outlook_with_no_line
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_2_3.txt").to_s
+    assert_equal "Outlook with a reply directly above line", EmailReplyParser.parse_reply(body)
+  end
+
   def test_parse_out_sent_from_iPhone
     body = IO.read EMAIL_FIXTURE_PATH.join("email_iPhone.txt").to_s
     assert_equal "Here is another email", EmailReplyParser.parse_reply(body)

--- a/test/emails/email_2_3.txt
+++ b/test/emails/email_2_3.txt
@@ -1,0 +1,10 @@
+Outlook with a reply directly above line
+
+From: CRM Comments [crm-comment@example.com]
+Sent: Friday, 23 March 2012 5:08 p.m.
+To: John S. Greene
+Subject: [contact:106] John Greene
+
+> A new comment has been added to the Contact named 'John Greene':
+>
+> I am replying to a comment.


### PR DESCRIPTION
In the native Microsoft Outlook client, when replying to an issue on GitHub.com or GitHub enterprise, the `________________________________________` seperator is not sent with the plaintext version of the email.
