### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See the [Ruby docs][rubydocs] for more information.
 
 [rubydocs]: http://rubydoc.info/gems/email_reply_parser/
 
-##Usage
+## Usage
 
 To parse reply body:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
