### PR TITLE
Remove new gmail reply format

### DIFF
--- a/email_reply_parser.gemspec
+++ b/email_reply_parser.gemspec
@@ -80,6 +80,7 @@ Gem::Specification.new do |s|
     test/emails/email_1_6.txt
     test/emails/email_1_7.txt
     test/emails/email_1_8.txt
+    test/emails/email_1_9.txt
     test/emails/email_2_1.txt
     test/emails/email_2_2.txt
     test/emails/email_BlackBerry.txt
@@ -98,4 +99,3 @@ Gem::Specification.new do |s|
   ## matches what you actually use.
   s.test_files = s.files.select { |path| path =~ /^test\/.*_test\.rb/ }
 end
-

--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -83,9 +83,13 @@ class EmailReplyParser
 
       # Check for multi-line reply headers. Some clients break up
       # the "On DATE, NAME <EMAIL> wrote:" line into multiple lines.
+      # Some clients, like Gmail, is using another format.
+      # Eg. "DATETIME NAME <EMAIL>:"
       if text =~ /^(?!On.*On\s.+?wrote:)(On\s(.+?)wrote:)$/m
         # Remove all new lines from the reply header.
         text.gsub! $1, $1.gsub("\n", " ")
+      elsif text =~ /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2} GMT.?\d{2}:\d{2} .*:)$/m
+        text.gsub! $1, " "
       end
 
       # Some users may reply directly above a line of underscores.

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -191,6 +191,11 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_equal EmailReplyParser.read(body).visible_text, EmailReplyParser.parse_reply(body)
   end
 
+  def test_gmail_reply_format
+    body = IO.read EMAIL_FIXTURE_PATH.join("email_1_9.txt").to_s
+    assert_equal EmailReplyParser.read(body).visible_text, EmailReplyParser.parse_reply(body)
+  end
+
   def test_one_is_not_on
     reply = email("email_one_is_not_on")
     assert_match(/One outstanding question/, reply.fragments[0].to_s)

--- a/test/emails/email_1_9.txt
+++ b/test/emails/email_1_9.txt
@@ -1,0 +1,53 @@
+Hi,
+
+2017-12-22 10:35 GMT-02:00 Abhishek Kona <abhishek@kona.com>:
+
+> Hi folks
+>
+> What is the best way to clear a Riak bucket of all key, values after
+> running a test?
+> I am currently using the Java HTTP API.
+
+You can list the keys for the bucket and call delete for each. Or if you
+put the keys (and kept track of them in your test) you can delete them
+one at a time (without incurring the cost of calling list first.)
+
+Something like:
+
+        String bucket = "my_bucket";
+        BucketResponse bucketResponse = riakClient.listBucket(bucket);
+        RiakBucketInfo bucketInfo = bucketResponse.getBucketInfo();
+
+        for(String key : bucketInfo.getKeys()) {
+            riakClient.delete(bucket, key);
+        }
+
+
+would do it.
+
+See also
+
+http://wiki.basho.com/REST-API.html#Bucket-operations
+
+which says
+
+"At the moment there is no straightforward way to delete an entire
+Bucket. There is, however, an open ticket for the feature. To delete all
+the keys in a bucket, you’ll need to delete them all individually."
+
+>
+> -Abhishek Kona
+>
+>
+> _______________________________________________
+> riak-users mailing list
+> riak-users@lists.basho.com
+> http://lists.basho.com/mailman/listinfo/riak-users_lists.basho.com
+
+
+
+
+_______________________________________________
+riak-users mailing list
+riak-users@lists.basho.com
+http://lists.basho.com/mailman/listinfo/riak-users_lists.basho.com


### PR DESCRIPTION
Gmail is using another format to replies: Eg. "DATETIME NAME <EMAIL>:"

This PR removes it too.