### PR TITLE
Roll back some over-broad text removal

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -88,12 +88,6 @@ class EmailReplyParser
         text.gsub! $1, $1.gsub("\n", " ")
       end
 
-      # Check for Windows Live multi-line reply headers.
-      if text =~ /^(From:\s.+?Subject:.+?)$/m
-        text.gsub! $1, $1.gsub("\n", " ")
-      end
-
-
       # Some users may reply directly above a line of underscores.
       # In order to ensure that these fragments are split correctly,
       # make sure that all lines of underscores are preceded by


### PR DESCRIPTION
Follow up to https://github.com/github/email_reply_parser/pull/54.

The change being rolled back here was intended to remove client-specific headers but could unintentionally remove large blocks of valid text.

/cc @derekprior @shayfrendt