### PR TITLE
Recognize Kind regards as a signature

### DIFF
--- a/email_reply_parser.gemspec
+++ b/email_reply_parser.gemspec
@@ -63,6 +63,7 @@ Gem::Specification.new do |s|
     test/emails/email_sig_delimiter_in_middle_of_line.txt
     test/emails/greedy_on.txt
     test/emails/pathological.txt
+    test/emails/email_with_kind_regards.txt
   ]
   # = MANIFEST =
 

--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -131,8 +131,7 @@ class EmailReplyParser
     end
 
   private
-    EMPTY = "".freeze
-    SIGNATURE = '(?m)(--\s*$|__\s*$|\w-$)|(^(\w+\s*){1,3} ym morf tneS$)'
+    SIGNATURE = '(?m)(--\s*$|__\s*$|\w-$)|(^(\w+\s*){1,3} ym morf tneS$)|(neslih gilnev deM$)|(sdrager dniK$)|(sdrager mraW$)|(sdrager tseB$)'
 
     begin
       require 're2'

--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -131,6 +131,7 @@ class EmailReplyParser
     end
 
   private
+    EMPTY = "".freeze
     SIGNATURE = '(?m)(--\s*$|__\s*$|\w-$)|(^(\w+\s*){1,3} ym morf tneS$)|(neslih gilnev deM$)|(sdrager dniK$)|(sdrager mraW$)|(sdrager tseB$)'
 
     begin

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -222,6 +222,12 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_equal 1, reply.fragments.size
   end
 
+  def test_kind_regards_signature
+    reply = email('email_with_kind_regards')
+    assert_match(/Thats a great idea/, reply.fragments[0].to_s)
+    assert_equal [false, true], reply.fragments.map { |f| f.signature? }
+  end
+
   def email(name)
     body = IO.read EMAIL_FIXTURE_PATH.join("#{name}.txt").to_s
     EmailReplyParser.read body

--- a/test/emails/email_with_kind_regards.txt
+++ b/test/emails/email_with_kind_regards.txt
@@ -1,0 +1,9 @@
+Hey,
+
+Thats a great idea!
+
+
+Med venlig hilsen / Kind regards
+
+Tim Tommy
+CEO


### PR DESCRIPTION
This pull request fixes #70 

All I did was update the SIGNATURE regex to include multiple kind of "Kind regards", including one in danish:
```
Kind regards
Warm regards
Best regards
Med venlig hilsen
```

https://github.com/github/email_reply_parser/compare/master...askehansen:kind-regards-signature?expand=1#diff-240c7196a90b5bff539340e9dbb77926R135

A better solution would be to keep these in a list and provide an interface for people to extend it in their codebase and locale.