### PR TITLE
Fix pathological backtracking in signature regexp

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -132,14 +132,8 @@ class EmailReplyParser
 
   private
     EMPTY = "".freeze
-    SIGNATURE = '(?m)(--\s*$|__\s*$|\w-$)|(^(\w+\s*){1,3} ym morf tneS$)'
-
-    begin
-      require 're2'
-      SIG_REGEX = RE2::Regexp.new(SIGNATURE)
-    rescue LoadError
-      SIG_REGEX = Regexp.new(SIGNATURE)
-    end
+    SIGNATURE = '(?m)(--\s*$|__\s*$|\w-$)|(^(\w+\s+){1,3}ym morf tneS$)'
+    SIG_REGEX = Regexp.new(SIGNATURE)
 
     ### Line-by-Line Parsing
 


### PR DESCRIPTION
This commit fixes the pathological backtracking in the regexp so that we
don't need the RE2 gem anymore.

The problem was the `(\w+\s*){1,3}` part.  Since we accept 0 or more
spaces, and 1 to 3 times, the regex engine would keep backtracking to
figure out if it should do 1, 2, or 3 matches.  We know we want at
least one match, and it *must* be followed by one or more spaces.  If we
remove the space before the "y", we can eliminate the backtracking by
making at least one space required (as the original regular expression
indicated)