### PR TITLE
handle mulitline reply headers in Gmail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pkg
 .ruby-version
+.byebug_history
+.idea

--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -83,7 +83,7 @@ class EmailReplyParser
 
       # Check for multi-line reply headers. Some clients break up
       # the "On DATE, NAME <EMAIL> wrote:" line into multiple lines.
-      if text =~ /^(?!On.*On\s.+?wrote:)(On\s(.+?)wrote:)$/m
+      if text =~ /(^On\s((?!On).)*wrote:$)/m
         # Remove all new lines from the reply header.
         text.gsub! $1, $1.gsub("\n", " ")
       end

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -202,13 +202,18 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_match(/^On Oct 1, 2012/, reply.fragments[1].to_s)
   end
 
-  def test_mulitple_on
+  def test_multiple_on
     reply = email("greedy_on")
     assert_match(/^On your remote host/, reply.fragments[0].to_s)
     assert_match(/^On 9 Jan 2014/, reply.fragments[1].to_s)
     assert_equal [false, true, false], reply.fragments.map { |f| f.quoted? }
     assert_equal [false, false, false], reply.fragments.map { |f| f.signature? }
     assert_equal [false, true, true], reply.fragments.map { |f| f.hidden? }
+  end
+
+  def test_multiple_replies
+    reply = email("email_multiple_replies")
+    assert_equal("TAKE 3 - testing once again", reply.fragments[0].to_s)
   end
 
   def test_pathological_emails

--- a/test/emails/email_multiple_replies.txt
+++ b/test/emails/email_multiple_replies.txt
@@ -1,0 +1,19 @@
+TAKE 3 - testing once again
+
+On Fri, Apr 3, 2020 at 12:32 PM Someone <
+someone@example.com> wrote:
+
+> TAKE 2 - Lets see what is posted now to the portal
+>
+> On Fri, Apr 3, 2020 at 12:31 PM Someone <
+> someone@example.com> wrote:
+>
+>> Lets see what is posted now to the portal
+>>
+>> On Fri, Apr 3, 2020 at 11:58 AM <projects@example.com> wrote:
+>>
+>>> Project~Stream - Comment Posted
+>>>
+>>> Someone1 added a comment on 04/03/2020 at 11:58 AM
+>>>
+>>> Full email test... Hopefully you don't see this in the reply


### PR DESCRIPTION
Gmail will break the reply header into multiple lines when it is
over 80 characters. As an example:

On Fri, Apr 3, 2020 at 12:32 PM Someone <someone@example.com> wrote:

Will become:

On Fri, Apr 3, 2020 at 12:32 PM Someone <
someone@example.com> wrote:

This was causing the reply header to be included in the final
returned body. This update matches the reply header across
multiple lines so it is excluded.