### PR TITLE
Add Missing Languages to CodeQL Advanced Configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'ruby' ]
+        language: [ 'ruby', 'actions' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both


### PR DESCRIPTION
We are working to [improve and streamline CodeQL configuration at GitHub](https://github.com/github/security-services/discussions/382#discussion-8527643). Your repository

1. Uses advanced CodeQL configuration 
2. Has languages in the repository that are not configured to be scanned by Code Scanning (CodeQL)

This PR adds those languages to your configuration. Merging this PR will ensure code scanning happens in your repo reliably and should eliminate future findings in [Security Findings](https://thehub.github.com/news/2022-10-19-security-findings/) (assuming you update the configuration as contents of your repository changes).

If your repository does not require or benefit from advanced config (e.g. for [compiled languages](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages)), you can change to [default setup](https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning#about-default-setup) in lieu of merging this PR.

If you have concerns or questions about this, please mention @github/prodsec-engineering in this PR or drop in our [slack channel](https://github-grid.enterprise.slack.com/archives/C05NT4Y6WSC) with your question.

If this configuration update will work for your repository, please approve and merge this pull request